### PR TITLE
Using triple quotes for multi line purposes

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -10,9 +10,9 @@ def main():
         from django.core.management import execute_from_command_line
     except ImportError as exc:
         raise ImportError(
-            "Couldn't import Django. Are you sure it's installed and "
-            "available on your PYTHONPATH environment variable? Did you "
-            "forget to activate a virtual environment?"
+            '''Couldn't import Django. Are you sure it's installed and 
+             available on your PYTHONPATH environment variable? Did you 
+             forget to activate a virtual environment?'''
         ) from exc
     execute_from_command_line(sys.argv)
 


### PR DESCRIPTION
Triple quotes only twice to help in data redundancy.